### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol server that provides **Google Search via Serper**. This server enables LLMs to get search result information from Google.
 
+<a href="https://glama.ai/mcp/servers/@garylab/serper-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@garylab/serper-mcp-server/badge" alt="Serper Server MCP server" />
+</a>
+
 ## Available Tools
 
 - `google_search` - Set [all the parameters](src/serper_mcp_server/schemas.py#L15)


### PR DESCRIPTION
This PR adds a badge for the [Serper MCP Server](https://glama.ai/mcp/servers/@garylab/serper-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@garylab/serper-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@garylab/serper-mcp-server/badge" alt="Serper Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.